### PR TITLE
add back AnVIL version of index.Rmd

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -3,20 +3,13 @@ title: "AnVIL Book Name "
 date: "`r format(Sys.time(), '%B %d, %Y')`"
 site: bookdown::bookdown_site
 documentclass: book
-bibliography: [book.bib, packages.bib]
+bibliography: [book.bib]
 biblio-style: apalike
 link-citations: yes
 description: "Description about Course/Book."
 favicon: assets/anvil_favicon.ico
 ---
 
-
-```{r include=FALSE}
-# automatically create a bib database for R packages
-knitr::write_bib(c(
-  .packages(), "bookdown", "knitr", "rmarkdown"
-), "packages.bib")
-```
 
 # About this Book {-}
 

--- a/index.Rmd
+++ b/index.Rmd
@@ -1,16 +1,23 @@
 ---
-title: "Course Name"
-date: "`r format(Sys.time(), '%B, %Y')`"
+title: "AnVIL Book Name "
+date: "`r format(Sys.time(), '%B %d, %Y')`"
 site: bookdown::bookdown_site
 documentclass: book
-bibliography: [book.bib]
+bibliography: [book.bib, packages.bib]
 biblio-style: apalike
 link-citations: yes
 description: "Description about Course/Book."
-favicon: assets/dasl_favicon.ico
-output:
-    bookdown::word_document2:
-      toc: true
+favicon: assets/anvil_favicon.ico
 ---
 
-# About this Course {-}
+
+```{r include=FALSE}
+# automatically create a bib database for R packages
+knitr::write_bib(c(
+  .packages(), "bookdown", "knitr", "rmarkdown"
+), "packages.bib")
+```
+
+# About this Book {-}
+
+This book is part of a series of books for the Genomic Data Science Analysis, Visualization, and Informatics Lab-space (AnVIL) of the National Human Genome Research Institute (NHGRI). Learn more about AnVIL by visiting `https://anvilproject.org` or reading the [preprint](https://www.biorxiv.org/content/10.1101/2021.04.22.436044v1).


### PR DESCRIPTION
This file got written over in the reset; this PR reverts it to the AnVIL version.

Actually, the AnVIL version also had a `knitr::write_bib()` code chunk.  It was there because it used to be in the OTTR_Template index.Rmd, but it's now been removed from OTTR_Template.  I assume from the name that it builds a bibliography of any packages that are used in the book...not sure how useful that is for AnVIL books since I don't think we're likely to be using much R.  I think delete it?  I left it out of this PR, but can add it back.

```{r include=FALSE}
# automatically create a bib database for R packages
knitr::write_bib(c(
  .packages(), "bookdown", "knitr", "rmarkdown"
), "packages.bib")
```