### PR TITLE
first draft sync.yml

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -1,0 +1,14 @@
+# For info on how to update this file see: https://github.com/marketplace/actions/repo-file-sync-action#%EF%B8%8F-sync-configuration
+
+group:
+  - files:
+      - source: .github/assets/
+        dest: .github/assets/
+        deleteOrphaned: true
+
+  # Repositories to receive changes
+    repos: |
+      jhudsl/AnVIL_Book_Getting_Started
+      jhudsl/AnVIL_Book_Instructor_Guide
+      jhudsl/AnVIL_Book_WDL
+###ADD NEW REPO HERE following the format above#


### PR DESCRIPTION
Set up a sync.yml to sync downstream AnVIL repositories.  Config file for this workflow: https://github.com/jhudsl/OTTR_Template/blob/main/.github/workflows/send-updates.yml

This will let us update things like the style assets in one place and pass the updates along to all AnVIL books.

I think we should only be syncing things unique to AnVIL; otherwise the downstream repos should get their updates directly from OTTR_Template.  That way this repo doesn't become a bottleneck for receiving OTTR_Template updates.